### PR TITLE
Add Job Namespace and Job Name printcolumns to NodeOperation CRD

### DIFF
--- a/api/v1alpha1/nodeoperation_types.go
+++ b/api/v1alpha1/nodeoperation_types.go
@@ -84,6 +84,8 @@ type NodeOperationStatus struct {
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:printcolumn:name="NodeName",type=string,JSONPath=`.spec.nodeName`
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
+// +kubebuilder:printcolumn:name="Job Namespace",type=string,JSONPath=`.status.JobNamespace`,priority=1
+// +kubebuilder:printcolumn:name="Job Name",type=string,JSONPath=`.status.JobName`,priority=1
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // NodeOperation is the Schema for the nodeoperations API

--- a/config/crd/bases/nodeops.k8s.preferred.jp_nodeoperations.yaml
+++ b/config/crd/bases/nodeops.k8s.preferred.jp_nodeoperations.yaml
@@ -13,6 +13,14 @@ spec:
   - JSONPath: .status.phase
     name: Phase
     type: string
+  - JSONPath: .status.JobNamespace
+    name: Job Namespace
+    priority: 1
+    type: string
+  - JSONPath: .status.JobName
+    name: Job Name
+    priority: 1
+    type: string
   - JSONPath: .metadata.creationTimestamp
     name: Age
     type: date


### PR DESCRIPTION
This PR adds "Job Namespace" and "Job Name" print columns to NodeOperation CRD. With this change, operators will be able to easily know which jobs are actually running.