### PR TITLE
Fix "JOB NAMESPACE" and "JOB NAME" columns are empty

### DIFF
--- a/api/v1alpha1/nodeoperation_types.go
+++ b/api/v1alpha1/nodeoperation_types.go
@@ -84,8 +84,8 @@ type NodeOperationStatus struct {
 //+kubebuilder:resource:scope=Cluster
 //+kubebuilder:printcolumn:name="NodeName",type=string,JSONPath=`.spec.nodeName`
 //+kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
-//+kubebuilder:printcolumn:name="Job Namespace",type=string,JSONPath=`.status.JobNamespace`,priority=1
-//+kubebuilder:printcolumn:name="Job Name",type=string,JSONPath=`.status.JobName`,priority=1
+//+kubebuilder:printcolumn:name="Job Namespace",type=string,JSONPath=`.status.jobReference.namespace`,priority=1
+//+kubebuilder:printcolumn:name="Job Name",type=string,JSONPath=`.status.jobReference.name`,priority=1
 //+kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // NodeOperation is the Schema for the nodeoperations API

--- a/config/crd/bases/nodeops.k8s.preferred.jp_nodeoperations.yaml
+++ b/config/crd/bases/nodeops.k8s.preferred.jp_nodeoperations.yaml
@@ -22,11 +22,11 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
-    - jsonPath: .status.JobNamespace
+    - jsonPath: .status.jobReference.namespace
       name: Job Namespace
       priority: 1
       type: string
-    - jsonPath: .status.JobName
+    - jsonPath: .status.jobReference.name
       name: Job Name
       priority: 1
       type: string


### PR DESCRIPTION
This PR fixes "JOB NAMESPACE" and "JOB NAME" columns in the output of `kubectl get nodeoperation -o wide` are empty.

**Before**

```
$ kubectl get nodeoperation -o wide
NAME                                            NODENAME                   PHASE       JOB NAMESPACE   JOB NAME   AGE
tutorial1                                       nodeops-tutorial-worker    Completed                              3m44s
tutorial1-nodeops-tutorial-worker-n8rn2-7g8jh   nodeops-tutorial-worker    Completed                              10s
tutorial2                                       nodeops-tutorial-worker    Pending                                3m4s
```

**After**

```
$  kubectl get nodeoperation -o wide
NAME        NODENAME                   PHASE       JOB NAMESPACE   JOB NAME                  AGE
tutorial1   nodeops-tutorial-worker    Completed   default         nodeops-tutorial1-4h5wr   98s
tutorial2   nodeops-tutorial-worker    Running     default         nodeops-tutorial2-qs9vj   11s
tutorial3   nodeops-tutorial-worker2   Pending                                               6s
```